### PR TITLE
Adding ExtendedVoxelLayer 

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -104,6 +104,7 @@ target_link_libraries(costmap_2d
 )
 
 add_library(layers
+  plugins/extended_voxel_layer.cpp
   plugins/footprint_layer.cpp
   plugins/inflation_layer.cpp
   plugins/obstacle_layer.cpp

--- a/costmap_2d/costmap_plugins.xml
+++ b/costmap_2d/costmap_plugins.xml
@@ -15,6 +15,9 @@
     <class type="costmap_2d::VoxelLayer"     base_class_type="costmap_2d::Layer">
       <description>Similar to obstacle costmap, but uses 3D voxel grid to store data.</description>
     </class>
+    <class type="costmap_2d::ExtendedVoxelLayer"     base_class_type="costmap_2d::Layer">
+      <description>Same as VoxelLayer but has the option to update only the detected area instead of bounding box. Also publishes which cells get cleared.</description>
+    </class>
     <class type="costmap_2d::VoxelWithFootprintLayer" base_class_type="costmap_2d::Layer">
       <description>
         Combines voxel and footprint plugins, so footprint-clearing is

--- a/costmap_2d/include/costmap_2d/extended_voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/extended_voxel_layer.h
@@ -1,0 +1,28 @@
+#ifndef COSTMAP_2D_EXTENDED_VOXEL_LAYER_H_
+#define COSTMAP_2D_EXTENDED_VOXEL_LAYER_H_
+
+#include <costmap_2d/voxel_layer.h>
+
+namespace costmap_2d
+{
+
+class ExtendedVoxelLayer : public VoxelLayer
+{
+public:
+  virtual void onInitialize();
+
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                            double* max_x, double* max_y);
+
+  virtual void updateCosts(Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
+
+protected:
+  virtual void publishClearing();
+
+  boost::shared_ptr<Costmap2D> linked_layer_;
+  ros::Publisher update_publisher_;
+};
+
+} //end of namespace costmap_2d
+
+#endif /* DIFFERENTIAL_UPDATE_H_ */

--- a/costmap_2d/include/costmap_2d/voxel_layer.h
+++ b/costmap_2d/include/costmap_2d/voxel_layer.h
@@ -84,6 +84,10 @@ public:
 protected:
   virtual void setupDynamicReconfigure(ros::NodeHandle& nh);
 
+  std::list<MapLocation> updated_cells_index_;
+
+  virtual void setUpdatedCells(boost::shared_ptr<bool[]> updated_columns, unsigned int updated_area_width, unsigned int offset_x, unsigned int offset_y);
+
 private:
   void reconfigureCB(costmap_2d::VoxelPluginConfig &config, uint32_t level);
   void clearNonLethal(double wx, double wy, double w_size_x, double w_size_y, bool clear_no_info);

--- a/costmap_2d/plugins/extended_voxel_layer.cpp
+++ b/costmap_2d/plugins/extended_voxel_layer.cpp
@@ -1,0 +1,89 @@
+#include <costmap_2d/extended_voxel_layer.h>
+#include <pluginlib/class_list_macros.h>
+#include <nav_msgs/GridCells.h>
+
+PLUGINLIB_EXPORT_CLASS(costmap_2d::ExtendedVoxelLayer, costmap_2d::Layer)
+
+namespace costmap_2d
+{
+
+void ExtendedVoxelLayer::onInitialize()
+{
+  VoxelLayer::onInitialize();
+  ros::NodeHandle private_nh("~/" + name_);
+
+  private_nh.param("combination_method", combination_method_, 1);
+  ROS_INFO("%s is using combination_method %d", name_.c_str(), combination_method_);
+
+  std::string clearing_publish_topic;
+  private_nh.param("clearing_publish_topic", clearing_publish_topic, std::string());
+
+  if (clearing_publish_topic != std::string())
+  {
+    update_publisher_ = private_nh.advertise<nav_msgs::GridCells>(clearing_publish_topic, 100);
+    ROS_INFO("%s: Publishes clearing updates to topic %s", name_.c_str(), update_publisher_.getTopic().c_str());
+  }
+}
+
+void ExtendedVoxelLayer::updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
+                                      double* max_x, double* max_y)
+{
+  VoxelLayer::updateBounds(robot_x, robot_y, robot_yaw, min_x, min_y, max_x, max_y);
+}
+
+void ExtendedVoxelLayer::updateCosts(Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
+{
+  if (!enabled_)
+    return;
+
+  if (update_publisher_)
+  {
+    publishClearing();
+  }
+
+  VoxelLayer::updateCosts(master_grid, min_i, min_j, max_i, max_j);
+}
+
+void ExtendedVoxelLayer::publishClearing()
+{
+  unsigned int x = 0;
+  unsigned int y = 0;
+
+  unsigned char value = 0;
+  std::list<geometry_msgs::Point> points;
+
+  for (std::list<MapLocation>::iterator updated_cell_index_it = updated_cells_index_.begin();
+      updated_cell_index_it != updated_cells_index_.end(); ++updated_cell_index_it)
+  {
+    x = (*updated_cell_index_it).x;
+    y = (*updated_cell_index_it).y;
+    value = costmap_[getIndex(x, y)];
+
+    if (value == FREE_SPACE || value == NO_INFORMATION)
+    {
+      geometry_msgs::Point point;
+      point.x = x;
+      point.y = y;
+      point.z = FREE_SPACE;
+      points.push_back(point);
+    }
+  }
+
+  nav_msgs::GridCells free_grid_cells;
+  free_grid_cells.header.stamp = ros::Time();
+  free_grid_cells.cells.resize(points.size());
+
+  ROS_DEBUG("%s is publishing clearing: %d cells", name_.c_str(), (unsigned int )points.size());
+
+  int cell_index = 0;
+
+  for (std::list<geometry_msgs::Point>::iterator points_it = points.begin(); points_it != points.end(); ++points_it)
+  {
+    free_grid_cells.cells[cell_index] = *points_it;
+    cell_index++;
+  }
+
+  update_publisher_.publish(free_grid_cells);
+}
+
+} //end of namespace costmap_2d

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -118,7 +118,7 @@ Costmap2DROS::Costmap2DROS(std::string name, tf::TransformListener& tf) :
     {
       std::string pname = static_cast<std::string>(my_list[i]["name"]);
       std::string type = static_cast<std::string>(my_list[i]["type"]);
-      ROS_INFO("Using plugin \"%s\"", pname.c_str());
+      ROS_INFO("Using plugin \"%s\" with type \"%s\"", pname.c_str(), type.c_str());
 
       boost::shared_ptr<Layer> plugin = plugin_loader_.createInstance(type);
       layered_costmap_->addPlugin(plugin);


### PR DESCRIPTION
Makes VoxelLayer keep track of what costmap cells are updated
Adds ExtendedVoxelLayer which adds the option to update with differential overwrite instead of bounding box
Adds publishing of which cells are cleared by the ExtendedVoxelLayer
Added type info output about costmap plugins to ROS_INFO
