### PR TITLE
Make resolution, inflation, inscribed, weight protected

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -130,6 +130,11 @@ public:
 protected:
   virtual void onFootprintChanged();
   boost::shared_mutex* access_;
+  
+  double resolution_;
+  double inflation_radius_;
+  double inscribed_radius_;
+  double weight_;
 
 private:
   /**
@@ -174,12 +179,9 @@ private:
   inline void enqueue(unsigned char* grid, unsigned int index, unsigned int mx, unsigned int my, unsigned int src_x,
                       unsigned int src_y);
 
-  double inflation_radius_, inscribed_radius_, weight_;
   unsigned int cell_inflation_radius_;
   unsigned int cached_cell_inflation_radius_;
   std::priority_queue<CellData> inflation_queue_;
-
-  double resolution_;
 
   bool* seen_;
   int seen_size_;


### PR DESCRIPTION
So they can be accessed from child classes. They are essential if someone wants to extend the Inflation layer.
